### PR TITLE
Handle migration to LSP-ltex-ls-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # LSP-ltex-ls
 
-Latex/Markdown grammar check support for Sublime's LSP plugin provided through [ltex-plus/ltex-ls-plus](https://github.com/ltex-plus/ltex-ls-plus).
-Until version 16 this client used the discontinued [valentjn/ltex-ls](https://github.com/valentjn/ltex-ls) server by Adam Voss.
+Latex/Markdown grammar check support for Sublime's LSP plugin provided through [valentjn/ltex-ls](https://github.com/valentjn/ltex-ls).
 
 ## Installation
 
-1. Install [LSP](https://packagecontrol.io/packages/LSP) via Package Control. If you prefer to install [ltex-plus/ltex-ls-plus](https://github.com/valentjn/ltex-ls) without `java` bundled, make sure a x64-version is in path and `JAVA_HOME` is set.
+1. Install [LSP](https://packagecontrol.io/packages/LSP) via Package Control. If you prefer to install [valentjn/ltex-ls](https://github.com/valentjn/ltex-ls) without `java` bundled, make sure a x64-version is in path and `JAVA_HOME` is set.
 2. Install this plugin.
 3. Restart Sublime.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LSP-ltex-ls
 
 > [!WARNING]
-> This package is deprecated. Please migrate to https://github.com/sublimelsp/LSP-ltex-ls-plus.
+> This package is deprecated. Please migrate to https://packagecontrol.io/packages/LSP-ltex-ls-plus.
 
 Latex/Markdown grammar check support for Sublime's LSP plugin provided through [valentjn/ltex-ls](https://github.com/valentjn/ltex-ls).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # LSP-ltex-ls
 
+> [!WARNING]
+> This package is deprecated. Please migrate to https://github.com/sublimelsp/LSP-ltex-ls-plus.
+
 Latex/Markdown grammar check support for Sublime's LSP plugin provided through [valentjn/ltex-ls](https://github.com/valentjn/ltex-ls).
 
 ## Installation

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "4.0.0": "messages/4.0.0.txt"
 }

--- a/messages/4.0.0.txt
+++ b/messages/4.0.0.txt
@@ -1,0 +1,8 @@
+LSP-ltex-ls 4.0.0
+-----------------
+
+!!!WARNING!!!
+
+This is the last version of this package. It won't get any more updates.
+
+Please remove this package and install its successor from https://github.com/sublimelsp/LSP-ltex-ls-plus instead.

--- a/messages/4.0.0.txt
+++ b/messages/4.0.0.txt
@@ -5,4 +5,4 @@ LSP-ltex-ls 4.0.0
 
 This is the last version of this package. It won't get any more updates.
 
-Please remove this package and install its successor from https://github.com/sublimelsp/LSP-ltex-ls-plus instead.
+Please remove this package and install its successor from https://packagecontrol.io/packages/LSP-ltex-ls-plus instead.

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,6 +1,12 @@
 LSP-ltex-ls
 -------------------------------
 
+!!!WARNING!!!
+
+This package is deprecated. Please migrate to https://github.com/sublimelsp/LSP-ltex-ls-plus
+
+---
+
 Latex/Markdown grammer check support for Sublime's LSP plugin provided through 
 https://github.com/valentjn/ltex-ls.
 

--- a/plugin.py
+++ b/plugin.py
@@ -22,10 +22,14 @@ from LSP.plugin import (
     unregister_plugin,
 )
 
+GITHUB_DL_URL = (
+    "https://github.com/valentjn/ltex-ls/releases/download/" + "{0}/ltex-ls-{0}{1}"
+)  # Format with Release-Tag
 GITHUB_RELEASES_API_URL = (
-    "https://api.github.com/repos/ltex-plus/ltex-ls-plus/releases/latest"
+    "https://api.github.com/repos/valentjn/ltex-" + "ls/releases/latest"
 )
-LATEST_TESTED_RELEASE = "18.6.1"
+SERVER_FOLDER_NAME = "ltex-ls-{}"  # Format with Release-Tag
+LATEST_TESTED_RELEASE = "16.0.0"  # Latest testet LTEX-LS release
 STORAGE_FOLDER_NAME = "LSP-ltex-ls"
 SETTINGS_FILENAME = "LSP-ltex-ls.sublime-settings"
 
@@ -80,6 +84,23 @@ def code_action_insert_settings(server_setting_key: str, value: dict[str, Any]):
 
 class LTeXLs(AbstractPlugin):
     @classmethod
+    def name(cls) -> str:
+        return "ltex-ls"
+
+    @classmethod
+    def basedir(cls) -> str:
+        """
+        The directry of this plugin in Package Storage.
+
+        :param      cls:  The class
+        :type       cls:  type
+
+        :returns:   The path this plugins base directory
+        :rtype:     str
+        """
+        return os.path.join(cls.storage_path(), STORAGE_FOLDER_NAME)
+
+    @classmethod
     def serverversion(cls) -> str:
         """
         Returns the version of ltex-ls to use. Can be None if
@@ -103,47 +124,6 @@ class LTeXLs(AbstractPlugin):
         return LATEST_TESTED_RELEASE
 
     @classmethod
-    def name(cls) -> str:
-        return "ltex-ls"
-
-    @classmethod
-    def lsp_name(cls):
-        if int(cls.serverversion().split(".")[0]) <= 16:
-            return "ltex-ls"
-        else:
-            return "ltex-ls-plus"
-
-    @classmethod
-    def github_dl_url(cls, suffix: str):
-        if int(cls.serverversion().split(".")[0]) <= 16:
-            return (
-                "https://github.com/valentjn/ltex-ls/releases/download/"
-                + "{0}/ltex-ls-{0}{1}".format(cls.serverversion(), suffix)
-            )
-        else:
-            return (
-                "https://github.com/ltex-plus/ltex-ls-plus/releases/download/"
-                + "{0}/ltex-ls-plus-{0}{1}".format(cls.serverversion(), suffix)
-            )
-
-    @classmethod
-    def server_folder_name(cls):
-        return "{}-{}".format(cls.lsp_name(), cls.serverversion())
-
-    @classmethod
-    def basedir(cls) -> str:
-        """
-        The directry of this plugin in Package Storage.
-
-        :param      cls:  The class
-        :type       cls:  type
-
-        :returns:   The path this plugins base directory
-        :rtype:     str
-        """
-        return os.path.join(cls.storage_path(), STORAGE_FOLDER_NAME)
-
-    @classmethod
     def serverdir(cls) -> str:
         """
         The directory of the server. In here are the "bin" and "lib"
@@ -156,7 +136,9 @@ class LTeXLs(AbstractPlugin):
                     Else None
         :rtype:     str
         """
-        return os.path.join(cls.basedir(), cls.server_folder_name())
+        return os.path.join(
+            cls.basedir(), SERVER_FOLDER_NAME.format(cls.serverversion())
+        )
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:
@@ -165,8 +147,7 @@ class LTeXLs(AbstractPlugin):
     @classmethod
     def additional_variables(cls) -> dict[str, str] | None:
         return {
-            "script": cls.lsp_name()
-            + (".bat" if platform.system() == "Windows" else ""),
+            "script": "ltex-ls.bat" if platform.system() == "Windows" else "ltex-ls",
             "serverdir": cls.serverdir(),
             "serverversion": cls.serverversion(),
         }
@@ -192,12 +173,9 @@ class LTeXLs(AbstractPlugin):
                     suffix = "-windows-x64.zip"
 
             sublime.status_message("ltex-ls: downloading")
-
             urllib.request.urlretrieve(
-                cls.github_dl_url(suffix),
-                archive_path,
+                GITHUB_DL_URL.format(cls.serverversion(), suffix), archive_path
             )
-
             sublime.status_message("ltex-ls: extracting")
             if suffix.endswith("tar.gz"):
                 archive = tarfile.open(archive_path, "r:gz")
@@ -208,10 +186,12 @@ class LTeXLs(AbstractPlugin):
             archive.extractall(tempdir)
             archive.close()
             shutil.move(
-                os.path.join(tempdir, cls.server_folder_name()),
+                os.path.join(tempdir, SERVER_FOLDER_NAME.format(cls.serverversion())),
                 cls.basedir(),
             )
-            sublime.status_message(f"ltex-ls: installed ltex-ls {cls.serverversion()}")
+            sublime.status_message(
+                f"ltex-ls: installed ltex-ls {cls.serverversion()}"
+            )
 
     @classmethod
     def can_start(

--- a/plugin.py
+++ b/plugin.py
@@ -53,9 +53,6 @@ def fetch_latest_release() -> None:
             pass
 
 
-fetch_latest_release()
-
-
 def code_action_insert_settings(server_setting_key: str, value: dict[str, Any]):
     """
     Adds a server setting initiated via custom ltex-la codeAction.
@@ -142,6 +139,7 @@ class LTeXLs(AbstractPlugin):
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:
+        fetch_latest_release()
         return not os.path.isdir(str(cls.serverdir()))
 
     @classmethod


### PR DESCRIPTION
Drop support for `ltex-ls-plus` and suggest migrating to https://github.com/sublimelsp/LSP-ltex-ls-plus

Fixes #13